### PR TITLE
Agile life

### DIFF
--- a/ComUtility/Include/ComUtility/Utility.h
+++ b/ComUtility/Include/ComUtility/Utility.h
@@ -55,11 +55,10 @@ public:
         m_agileRef.Release();
     }
 
-    // Prevent moving the agile reference into another thread. This can cause memory leaks
     AgilePtr(const AgilePtr&) = default;
-    AgilePtr(AgilePtr&& in) = delete;
+    AgilePtr(AgilePtr&& in) = default;
     AgilePtr& operator=(const AgilePtr& rhs) = default;
-    AgilePtr& operator=(AgilePtr&& rhs) = delete;
+    AgilePtr& operator=(AgilePtr&& rhs) = default;
 
     CComPtr<T> Get() const
     {


### PR DESCRIPTION
Added tests demonstrate that move is actually safe, with one condition.

CComPtr<IAgileReference>::Release should have access to thread where IAgileReference was created to destroy it. 