### PR TITLE
Add example showing how to pass a struct form a COM server to a COM client.

### DIFF
--- a/Interfaces/IPetShop.idl
+++ b/Interfaces/IPetShop.idl
@@ -3,6 +3,12 @@ import "ocidl.idl";
 import "IDog.idl";
 import "IHen.idl";
 
+typedef struct {
+	BSTR Street;
+	BSTR PostalCode;
+	BSTR City;
+} Address;
+
 [
 	oleautomation,
 	object,
@@ -12,4 +18,5 @@ import "IHen.idl";
 interface IPetShop : IUnknown
 {
 	HRESULT BuyDog([out, retval] IDog** dog);
+	HRESULT GetAddress([out, retval] Address* address);
 };

--- a/ManagedServer/PetShop.cs
+++ b/ManagedServer/PetShop.cs
@@ -18,5 +18,14 @@ namespace ManagedServer
             Type comServerType = Type.GetTypeFromCLSID(new Guid("d162d2f7-cdf4-44bc-8018-6058420bcfdc"));
             return Activator.CreateInstance(comServerType ?? throw new COMException()) as IDog;
         }
+
+        public Address GetAddress()
+        {
+            var address = new Address();
+            address.Street = "Suhms gate";
+            address.PostalCode = "0363";
+            address.City = "Oslo";
+            return address;
+        }
     }
 }

--- a/Tests/ManagedServerTests.cpp
+++ b/Tests/ManagedServerTests.cpp
@@ -33,3 +33,29 @@ TEST(ManagedServerTests,
 
     HR(dog->Sit()); // Good dog
 }
+
+
+TEST(ManagedServerTests,
+    RequireThat_GetAddress_ReturnsShopAddress)
+{
+    CLSID petShopClsid{};
+    HR(CLSIDFromString(L"{5011c315-994d-49b4-b737-03a846f590a0}", &petShopClsid));
+
+    ComPtr<IPetShop> petShop;
+    HR(CoCreateInstance(petShopClsid, nullptr, CLSCTX_INPROC_SERVER, __uuidof(IPetShop), &petShop));
+
+    Address address;
+
+    HR(petShop->GetAddress(&address));
+
+    EXPECT_STREQ(address.Street, L"Suhms gate");
+    EXPECT_STREQ(address.PostalCode, L"0363");
+    EXPECT_STREQ(address.City, L"Oslo");
+
+    // With COM, the caller is responsible for releasing resources from getters.
+    // This becomes quite inconvenient with structs of strings, since we can't make generic
+    // RAII wrappers for structs.
+    SysFreeString(address.Street);
+    SysFreeString(address.PostalCode);
+    SysFreeString(address.City);
+}


### PR DESCRIPTION
This is interesting, because in with COM, a client is responsible for releasing memory that the server allocated for output arguments.