### PR TITLE
Add an example that shows how to create COM objects in a separate process

### DIFF
--- a/AtlFreeServer/GuardDog.cpp
+++ b/AtlFreeServer/GuardDog.cpp
@@ -155,6 +155,20 @@ HRESULT __stdcall DllGetClassObject(CLSID const & clsid,
                                     IID const & iid,
                                     void ** result)
 {
+    // If you want to play with tests or tutorials involving out-of-process activation,
+    // uncomment the code below. This allows attaching to the dllhost.exe process once
+    // CoCreateInstance(... CLSCTX_LOCAL_SERVER ...) has been called.
+    //
+    // To find the process id of the dllhost.exe that hosts the COM server, enable the 'Command line'
+    // column in task manager, and look for the process with command line containing
+    //
+    //    /Processid:{2b083fea-3681-4c9b-9ed1-3e866124a58d}
+    //
+    // The guid is the 'AppID' that was used when registering the AtlFreeServer
+
+    //while (!IsDebuggerPresent())
+    //    Sleep(100);
+
     assert(result);
     *result = nullptr;
 

--- a/AtlFreeServer/Registration.cpp
+++ b/AtlFreeServer/Registration.cpp
@@ -101,14 +101,38 @@ struct Entry
 
 static Entry Table[] =
 {
+    // Register the dll 'AppID' allows the COM dll to run as an out of
+    // process COM server under the dllhost.exe. This requires creating
+    // a new guid for the AppID, and adding the DllSurrogate key. The
+    // AppId is just another guid that registration of COM classes can
+    // refer to as their AppID.
+    {
+        L"Software\\Classes\\AppID\\{2b083fea-3681-4c9b-9ed1-3e866124a58d}",
+        EntryOption::Delete,
+        nullptr,
+        L"AtlFreeServer Object"
+    },
+    {
+        L"Software\\Classes\\AppID\\{2b083fea-3681-4c9b-9ed1-3e866124a58d}",
+        EntryOption::None,
+        L"DllSurrogate",
+        L""
+    },
 
     // Registration of GuardDog COM class
-
-    {   // Adds the UID of the COM GuardDog class as key in the Registry
+    {
+        // Adds the UID of the COM GuardDog class as key in the Registry
         L"Software\\Classes\\CLSID\\{d162d2f7-cdf4-44bc-8018-6058420bcfdc}",
         EntryOption::Delete,
         nullptr,
         L"GuardDog COM class"
+    },
+    {   // Associates the GuardDog with the AppID, and allows creating GuardDogs
+        // in a separate process.
+        L"Software\\Classes\\CLSID\\{d162d2f7-cdf4-44bc-8018-6058420bcfdc}",
+        EntryOption::None,
+        L"AppID",
+        L"{2b083fea-3681-4c9b-9ed1-3e866124a58d}"
     },
     {   // Adds InprocServer32 subkey to GuardDog COM class with a default value containing the dll filename
         L"Software\\Classes\\CLSID\\{d162d2f7-cdf4-44bc-8018-6058420bcfdc}\\InprocServer32",

--- a/TutorialsAndTests/Tutorials/CreatingComObjectsWithCoCreateInstance.cpp
+++ b/TutorialsAndTests/Tutorials/CreatingComObjectsWithCoCreateInstance.cpp
@@ -84,3 +84,38 @@ TEST(CreatingComObjects,
 
     EXPECT_NE(dog, nullptr);
 }
+
+
+//
+// How to create objects in a different process?
+//
+TEST(CreatingComObjects,
+    how_does_cocreateinstance_create_objects_in_a_separate_process)
+{
+    ComPtr<IDog> dog;
+
+    // As long as the COM server is enabling activation through the COM surrogate, the only change
+    // we need to do to create the objects on a separate server, is to change the CLSCTX_INPROC_SERVER
+    // to CLSCTX_LOCAL_SERVER.
+    //
+    // To play with this in the debugger, uncomment the first code lines in AtlFreeServer/GuardDog.cpp
+    // that sleeps until debugger is attached, and attach to the corresponding dllhost.exe once
+    // CoCreateInstance starts to hang.
+    //
+    // To find the process id of the dllhost.exe that hosts the COM server, enable the 'Command line'
+    // column in task manager, and look for the process with command line containing
+    //
+    //    /Processid:{2b083fea-3681-4c9b-9ed1-3e866124a58d}
+    //
+    // The guid is the 'AppID' that was used when registering the AtlFreeServer
+    //
+
+    HR(CoCreateInstance(
+        __uuidof(GuardDog),
+        nullptr,
+        CLSCTX_LOCAL_SERVER,
+        __uuidof(IDog),
+        reinterpret_cast<void**>(dog.GetAddressOf())));
+
+    EXPECT_NE(dog, nullptr);
+}


### PR DESCRIPTION
Also enable out-of-process activation for the GuardDog class, to show exactly what is needed to enable out-of-process activation for dlls.