### PR TITLE
WinrtServer: Add example of how to use structs

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -42,3 +42,22 @@ TEST(WinrtServerTests, RequireThat_GivingProgrammerCoffee_IncreasesMotviation)
 
     EXPECT_TRUE(motivationAfterCoffee > motivationBeforeCoffee);
 }
+
+TEST(WinrtServerTests, RequireThat_ProgrammerCanAdd3dCoordinates)
+{
+    // Initialize the Windows Runtime.
+    RoInitializeWrapper initialize(RO_INIT_SINGLETHREADED);
+    HR(initialize);
+
+    ComPtr<ABI::WinrtServer::IProgrammer> programmer;
+    HR(ActivateInstance(HStringReference(L"WinrtServer.Programmer").Get(), programmer.GetAddressOf()));
+
+    ABI::WinrtServer::Pos3 a = { 1, 2, 3 };
+    ABI::WinrtServer::Pos3 b = { 1, 2, 3 };
+    ABI::WinrtServer::Pos3 sum = {}; // zero-initialize
+    HR(programmer->Add(a, b, &sum));
+
+    EXPECT_EQ(sum.x, a.x + b.x);
+    EXPECT_EQ(sum.y, a.y + b.y);
+    EXPECT_EQ(sum.z, a.z + b.z);
+}

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -18,4 +18,13 @@ namespace winrt::WinrtServer::implementation
     {
         return m_motivation;
     }
+
+    Pos3 Programmer::Add(Pos3 a, Pos3 b)
+    {
+        Pos3 sum = {}; // zero-initialize
+        sum.x = a.x + b.x;
+        sum.y = a.y + b.y;
+        sum.z = a.z + b.z;
+        return sum;
+    }
 }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -11,6 +11,7 @@ namespace winrt::WinrtServer::implementation
         void GiveCoffee();
         void WriteDocumentation();
         int Motivation();
+        Pos3 Add(Pos3 a, Pos3 b);
 
 
     private:

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -1,5 +1,11 @@
 namespace WinrtServer
 {
+    struct Pos3 {
+        Single x;
+        Single y;
+        Single z;
+    };
+
     [default_interface]
     runtimeclass Programmer
     {
@@ -8,5 +14,6 @@ namespace WinrtServer
         Int32 Motivation{ get; };
         void GiveCoffee();
         void WriteDocumentation();
+        Pos3 Add(Pos3 a, Pos3 b);
     }
 }


### PR DESCRIPTION
Introduce a `Pos3` struct for 3D coordinates that is passed as both input & output argument to a new Add method.

NOTICE: Structs members are _not_ zero-initialized by default, so it's good practice to zero-initialize them explicitly before usage to avoid "random" state in release builds.