### PR TITLE
Illustrate potential issues when returning structs containing dynamically allocated strings

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -61,3 +61,29 @@ TEST(WinrtServerTests, RequireThat_ProgrammerCanAdd3dCoordinates)
     EXPECT_EQ(sum.y, a.y + b.y);
     EXPECT_EQ(sum.z, a.z + b.z);
 }
+
+TEST(WinrtServerTests, RequireThat_GetFavorites_ReturnsStructsOfStrings)
+{
+    // Initialize the Windows Runtime.
+    RoInitializeWrapper initialize(RO_INIT_SINGLETHREADED);
+    HR(initialize);
+
+    ComPtr<ABI::WinrtServer::IProgrammer> programmer;
+    HR(ActivateInstance(HStringReference(L"WinrtServer.Programmer").Get(), programmer.GetAddressOf()));
+
+    ABI::WinrtServer::Favorites favorites{};
+    HR(programmer->GetFavorites(&favorites));
+
+    // It is the responsible of the caller to ensure that resources that the server
+    // allocated to proide output data are released. When working with structs,
+    // this can easily cause memory leaks. These are avoided by taking ownership
+    // of each struct member
+    HString favoriteDrink;
+    favoriteDrink.Attach(favorites.FavoriteDrink);
+
+    HString favoriteActivity;
+    favoriteActivity.Attach(favorites.FavoriteActivity);
+
+    EXPECT_STREQ(favoriteDrink.GetRawBuffer(nullptr), L"Coffee");
+    EXPECT_STREQ(favoriteActivity.GetRawBuffer(nullptr), L"Coding");
+}

--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -79,10 +79,10 @@ TEST(WinrtServerTests, RequireThat_GetFavorites_ReturnsStructsOfStrings)
     // this can easily cause memory leaks. These are avoided by taking ownership
     // of each struct member
     HString favoriteDrink;
-    favoriteDrink.Attach(favorites.FavoriteDrink);
+    favoriteDrink.Attach(favorites.Drink);
 
     HString favoriteActivity;
-    favoriteActivity.Attach(favorites.FavoriteActivity);
+    favoriteActivity.Attach(favorites.Activity);
 
     EXPECT_STREQ(favoriteDrink.GetRawBuffer(nullptr), L"Coffee");
     EXPECT_STREQ(favoriteActivity.GetRawBuffer(nullptr), L"Coding");

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -19,6 +19,15 @@ namespace winrt::WinrtServer::implementation
         return m_motivation;
     }
 
+    Favorites Programmer::GetFavorites()
+    {
+        Favorites favorites{};
+        favorites.FavoriteActivity = L"Coding";
+        favorites.FavoriteDrink = L"Coffee";
+
+        return favorites;
+    }
+
     Pos3 Programmer::Add(Pos3 a, Pos3 b)
     {
         Pos3 sum = {}; // zero-initialize

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -22,8 +22,8 @@ namespace winrt::WinrtServer::implementation
     Favorites Programmer::GetFavorites()
     {
         Favorites favorites{};
-        favorites.FavoriteActivity = L"Coding";
-        favorites.FavoriteDrink = L"Coffee";
+        favorites.Activity = L"Coding";
+        favorites.Drink = L"Coffee";
 
         return favorites;
     }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -12,7 +12,7 @@ namespace winrt::WinrtServer::implementation
         void WriteDocumentation();
         int Motivation();
         Pos3 Add(Pos3 a, Pos3 b);
-
+        Favorites GetFavorites();
 
     private:
         int m_motivation = 0;

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -6,6 +6,11 @@ namespace WinrtServer
         Single z;
     };
 
+    struct Favorites {
+        String FavoriteDrink;
+        String FavoriteActivity;
+    };
+
     [default_interface]
     runtimeclass Programmer
     {
@@ -15,5 +20,6 @@ namespace WinrtServer
         void GiveCoffee();
         void WriteDocumentation();
         Pos3 Add(Pos3 a, Pos3 b);
+        Favorites GetFavorites();
     }
 }

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -7,8 +7,8 @@ namespace WinrtServer
     };
 
     struct Favorites {
-        String FavoriteDrink;
-        String FavoriteActivity;
+        String Drink;
+        String Activity;
     };
 
     [default_interface]


### PR DESCRIPTION
Illustrate potential issues when returning structs of strings from a COM server. The caller has to deallocate struct members that were dynamically allocated to prevent memory leaks