### PR TITLE
WinrtServer: Get rid of double copying of WinrtServer.h

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -1,7 +1,7 @@
 #include "../pch.h"
 #include <gtest/gtest.h>
 #include <ComUtility/Utility.h>
-#include <WinrtServer/WinrtServer.h>
+#include <winrt/WinrtServer.h>
 
 #pragma comment (lib, "runtimeobject.lib")
 

--- a/WinrtServer/CreateCppInterop.bat
+++ b/WinrtServer/CreateCppInterop.bat
@@ -1,12 +1,8 @@
 set OutDir=%1
 
-if exist %OutDir%Include\WinrtServer\winrt\ (
-    del /s /q %OutDir%Include\WinrtServer\winrt\ || exit /b 1
+if exist %OutDir%Include\winrt\ (
+    del /s /q %OutDir%Include\winrt\ || exit /b 1
 )
 
-REM Copy the primary WinrtServer.h. This is a workaround for include path issues in generated files
-xcopy /I "Generated Files\winrt\WinrtServer.h" %OutDir%Include\WinrtServer\
-
 REM Copy the winrt folder. 
-xcopy /E /I "Generated Files\winrt\WinrtServer*" %OutDir%Include\WinrtServer\winrt\ || exit /b 1
-
+xcopy /E /I "Generated Files\winrt\WinrtServer*" %OutDir%Include\winrt\ || exit /b 1


### PR DESCRIPTION
Follow existing header folder structure as generated by CppWinRT.