### PR TITLE
Demonstrate resource management when returning structs of strings with winrt

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -43,3 +43,16 @@ TEST(WinrtServerTests, RequireThat_ProgrammerCanAdd3dCoordinates)
     EXPECT_EQ(sum.y, a.y + b.y);
     EXPECT_EQ(sum.z, a.z + b.z);
 }
+
+TEST(WinrtServerTests, RequireThat_GetFavorites_ReturnsStructWithStrings)
+{
+    init_apartment(winrt::apartment_type::single_threaded);
+
+    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
+    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+
+    auto favorites = programmer.GetFavorites();
+
+    EXPECT_EQ(favorites.Activity, L"Coding");
+    EXPECT_EQ(favorites.Drink, L"Coffee");
+}

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -27,4 +27,12 @@ namespace winrt::WinrtServer::implementation
         sum.z = a.z + b.z;
         return sum;
     }
+
+    Favorites Programmer::GetFavorites()
+    {
+        Favorites favorites{};
+        favorites.Activity = L"Coding";
+        favorites.Drink = L"Coffee";
+        return favorites;
+    }
 }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -12,7 +12,7 @@ namespace winrt::WinrtServer::implementation
         void WriteDocumentation();
         int Motivation();
         Pos3 Add(Pos3 a, Pos3 b);
-
+        Favorites GetFavorites();
 
     private:
         int m_motivation = 0;

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -6,6 +6,11 @@ namespace WinrtServer
         Single z;
     };
 
+    struct Favorites {
+        String Drink;
+        String Activity;
+    };
+
     [default_interface]
     runtimeclass Programmer
     {
@@ -15,5 +20,7 @@ namespace WinrtServer
         void GiveCoffee();
         void WriteDocumentation();
         Pos3 Add(Pos3 a, Pos3 b);
+
+        Favorites GetFavorites();
     }
 }


### PR DESCRIPTION
As opposed to classic COM, resource handling becomes easier with winrt, because the returned structs are composed of RAII types that handles releasing memory.