### PR TITLE
WinrtServer: Demonstrate byte-array passing

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -56,3 +56,16 @@ TEST(WinrtServerTests, RequireThat_GetFavorites_ReturnsStructWithStrings)
     EXPECT_EQ(favorites.Activity, L"Coding");
     EXPECT_EQ(favorites.Drink, L"Coffee");
 }
+
+TEST(WinrtServerTests, RequireThat_Buffer_ReturnsCorrectValues)
+{
+    init_apartment(winrt::apartment_type::single_threaded);
+
+    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
+    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+
+    auto buffer = programmer.Buffer();
+
+    EXPECT_EQ(buffer.size(), 8u);
+    EXPECT_EQ(buffer[0], 1);
+}

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -4,6 +4,10 @@
 
 namespace winrt::WinrtServer::implementation
 {
+    Programmer::Programmer() {
+        m_buffer = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    }
+
     void Programmer::GiveCoffee()
     {
         ++m_motivation;
@@ -34,5 +38,11 @@ namespace winrt::WinrtServer::implementation
         favorites.Activity = L"Coding";
         favorites.Drink = L"Coffee";
         return favorites;
+    }
+
+    com_array<uint8_t> Programmer::Buffer()
+    {
+        // return a copy
+        return com_array<uint8_t>{ m_buffer.begin(), m_buffer.end() };
     }
 }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -6,16 +6,18 @@ namespace winrt::WinrtServer::implementation
 {
     struct Programmer : ProgrammerT<Programmer>
     {
-        Programmer() = default;
+        Programmer();
 
         void GiveCoffee();
         void WriteDocumentation();
         int Motivation();
         Pos3 Add(Pos3 a, Pos3 b);
         Favorites GetFavorites();
+        com_array<uint8_t> Buffer();
 
     private:
         int m_motivation = 0;
+        std::vector<uint8_t> m_buffer;
     };
 }
 

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -9,6 +9,8 @@ namespace WinrtServer
     struct Favorites {
         String Drink;
         String Activity;
+
+        //UInt8[] buffer; // arrays in structs not supported (see https://github.com/MicrosoftDocs/winrt-related/issues/112)
     };
 
     [default_interface]

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -22,5 +22,6 @@ namespace WinrtServer
         Pos3 Add(Pos3 a, Pos3 b);
 
         Favorites GetFavorites();
+        UInt8[] Buffer{ get; };
     }
 }


### PR DESCRIPTION
Introduce a new Buffer() property-method that returns a `Uint8[]` array which translates to `com_array<uint8_t>` in C++.