### PR TITLE
WinrtServer: Extract Programmer methods into an explicit IProgrammer interface

### DIFF
--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -13,17 +13,20 @@ namespace WinrtServer
         //UInt8[] buffer; // arrays in structs not supported (see https://github.com/MicrosoftDocs/winrt-related/issues/112)
     };
 
-    [default_interface]
-    runtimeclass Programmer
-    {
-        Programmer();
-
+    [uuid(D3ABAFC1-C65D-40F2-965A-7CCCB4B51BCD)] // explicit interface GUID instead of auto-generated
+    interface IProgrammer {
         Int32 Motivation{ get; };
         void GiveCoffee();
         void WriteDocumentation();
         Pos3 Add(Pos3 a, Pos3 b);
 
-        Favorites GetFavorites();
         UInt8[] Buffer{ get; };
+    }
+
+    runtimeclass Programmer : [default] IProgrammer
+    {
+        Programmer();
+
+        Favorites GetFavorites();
     }
 }


### PR DESCRIPTION
I like keeping the interface separate from the concrete class implementation. Keep one method in the concrete class to show that it's possible to mix&match.

Also, demonstrate how to use explicit interface GUIDs to make them more "deterministic".
