### PR TITLE
Remove explicit linking that is no longer needed after switching to t…

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -3,7 +3,6 @@
 #include <ComUtility/Utility.h>
 #include <winrt/WinrtServer.h>
 
-#pragma comment (lib, "runtimeobject.lib")
 
 TEST(WinrtServerTests, RequireThat_ActivateInstance_CreatesProgrammer)
 {

--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -1,6 +1,5 @@
 #include "../pch.h"
 #include <gtest/gtest.h>
-#include <ComUtility/Utility.h>
 #include <winrt/WinrtServer.h>
 
 


### PR DESCRIPTION
…he C++ WinRT language projection headers in <winrt/WinrtServer.h>.