### PR TITLE
WinRT: Simplify class creation

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -15,8 +15,7 @@ TEST(WinrtServerTests, RequireThat_GivingProgrammerCoffee_IncreasesMotviation)
 {
     init_apartment(winrt::apartment_type::single_threaded);
 
-    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
-    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+    winrt::WinrtServer::Programmer programmer; // will trigger WinrtServer.dll loading
 
     const int motivationBeforeCoffee = programmer.Motivation();
 
@@ -29,8 +28,7 @@ TEST(WinrtServerTests, RequireThat_ProgrammerCanAdd3dCoordinates)
 {
     init_apartment(winrt::apartment_type::single_threaded);
 
-    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
-    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+    winrt::WinrtServer::Programmer programmer; // will trigger WinrtServer.dll loading
 
     winrt::WinrtServer::Pos3 a = { 1, 2, 3 };
     winrt::WinrtServer::Pos3 b = { 1, 2, 3 };
@@ -46,8 +44,7 @@ TEST(WinrtServerTests, RequireThat_GetFavorites_ReturnsStructWithStrings)
 {
     init_apartment(winrt::apartment_type::single_threaded);
 
-    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
-    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+    winrt::WinrtServer::Programmer programmer; // will trigger WinrtServer.dll loading
 
     auto favorites = programmer.GetFavorites();
 
@@ -59,8 +56,7 @@ TEST(WinrtServerTests, RequireThat_Buffer_ReturnsCorrectValues)
 {
     init_apartment(winrt::apartment_type::single_threaded);
 
-    const auto factory = winrt::get_activation_factory(L"WinrtServer.Programmer");
-    const auto programmer = factory.ActivateInstance<winrt::WinrtServer::Programmer>();
+    winrt::WinrtServer::Programmer programmer; // will trigger WinrtServer.dll loading
 
     auto buffer = programmer.Buffer();
 


### PR DESCRIPTION
Leverage WinRT C++ language projection to simplify WinRT class creation without explicit factories in the client code as already done in https://github.com/forderud/WinRT_test.

### Problem before PR #42 was merged (already solved)
WARNING: Doesn't work yet since it triggers the following linker error:
```
2>WinrtServerTests.obj : error LNK2019: unresolved external symbol "public: __cdecl winrt::WinrtServer::Programmer::Programmer(void)" (??0Programmer@WinrtServer@winrt@@QEAA@XZ) referenced in function "private: virtual void __cdecl WinrtServerTests_RequireThat_Buffer_ReturnsCorrectValues_Test::TestBody(void)" (?TestBody@WinrtServerTests_RequireThat_Buffer_ReturnsCorrectValues_Test@@EEAAXXZ)
2>C:\Dev\com_samples\Build\Output\TutorialsAndTests.exe : fatal error LNK1120: 1 unresolved externals
```

Root cause seem to be lack of stub impl. for the `Programmer` class constructor in the generated `WinrtServer.h`:
![image](https://user-images.githubusercontent.com/2671400/146532759-b1d2e5ce-4be3-4df7-96ae-b40acf8b24e9.png)

It should have been something like this:
```
WINRT_EXPORT namespace winrt::WinrtServer
{
    inline Programmer::Programmer() :
        Programmer(impl::call_factory_cast<Programmer(*)(winrt::Windows::Foundation::IActivationFactory const&), Programmer>([](winrt::Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<Programmer>(); }))
    {
    }
}
```