### PR TITLE
Reorganize how WinrtServer is consumed to avoid need for copying generated files

### DIFF
--- a/TutorialsAndTests/TutorialsAndTests.vcxproj
+++ b/TutorialsAndTests/TutorialsAndTests.vcxproj
@@ -129,6 +129,11 @@
   <ItemGroup>
     <Manifest Include="TutorialsAndTests.exe.manifest" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WinrtServer\WinrtServer.vcxproj">
+      <Project>{1d97f756-aeb2-4070-b845-0e9c868b4cef}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\gmock.1.11.0\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" />

--- a/WinrtServer/CreateCppInterop.bat
+++ b/WinrtServer/CreateCppInterop.bat
@@ -1,9 +1,0 @@
-set OutDir=%1
-
-if exist %OutDir%Include\winrt\ (
-    del /s /q %OutDir%Include\winrt\ || exit /b 1
-)
-
-REM Copy the winrt folder. 
-xcopy /E /I "Generated Files\winrt\base.h" %OutDir%Include\winrt\ || exit /b 1
-xcopy /E /I "Generated Files\winrt\WinrtServer*" %OutDir%Include\winrt\ || exit /b 1

--- a/WinrtServer/WinrtServer.vcxproj
+++ b/WinrtServer/WinrtServer.vcxproj
@@ -94,10 +94,6 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <PostBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CreateCppInterop.bat $(OutDir)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating C++ interop</Message>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -107,10 +103,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PostBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CreateCppInterop.bat $(OutDir)</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating C++ interop</Message>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -131,7 +123,6 @@
     <Midl Include="Programmer.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="CreateCppInterop.bat" />
     <None Include="packages.config" />
     <None Include="readme.md" />
     <None Include="WinrtServer.def" />

--- a/WinrtServer/WinrtServer.vcxproj.filters
+++ b/WinrtServer/WinrtServer.vcxproj.filters
@@ -22,7 +22,6 @@
   <ItemGroup>
     <None Include="WinrtServer.def" />
     <None Include="packages.config" />
-    <None Include="CreateCppInterop.bat" />
     <None Include="readme.md" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Instead of copying generated files from WinrtServer to output folder, we can instead use a project reference.

When compiling the TutorialsAndTests.vcxproj project, it now generates the necessary files into

    Build\Intermediate\TutorialsAndTests\Generated Files\winrt

I think this approach will scale better if we have more than one winrt component in the solution.

If the WinrtServer should be consumed by other projects than the projects in this solution, I think those projects should generate their own files using cppwinrt.exe.

See also https://docs.microsoft.com/en-us/windows/uwp/winrt-components/create-a-windows-runtime-component-in-cppwinrt