### PR TITLE
Add link to WinRT type listing overview

### DIFF
--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -1,3 +1,5 @@
+// WinRT type listing: https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system
+
 namespace WinrtServer
 {
     struct Pos3 {


### PR DESCRIPTION
If this IDL file is intended for educational purposes, then it could be nice to make the list of in-built types easily accessible.