### PR TITLE
Allow sharing virtual python environment

### DIFF
--- a/PyComServer/PyComServer.pyproj
+++ b/PyComServer/PyComServer.pyproj
@@ -14,7 +14,7 @@
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <CommandLineArguments>/regserver</CommandLineArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <InterpreterId>MSBuild|env|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|buildenv|$(MSBuildProjectFullPath)</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,10 +33,10 @@
     <Content Include="requirements.txt" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include="env\">
-      <Id>env</Id>
+    <Interpreter Include="..\Build\buildenv\">
+      <Id>buildenv</Id>
       <Version>3.9</Version>
-      <Description>env (Python 3.9 (64-bit))</Description>
+      <Description>buildenv (Python 3.9 (64-bit))</Description>
       <InterpreterPath>Scripts\python.exe</InterpreterPath>
       <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
       <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>

--- a/PyComServer/RegPyComServer.bat
+++ b/PyComServer/RegPyComServer.bat
@@ -3,7 +3,7 @@ pushd %~dp0
 
 @echo on
 
-py -3 -m venv ..\Build\buildenv || exit /b 1
+py -3.9 -m venv ..\Build\buildenv || exit /b 1
 call ..\Build\buildenv\Scripts\Activate.bat || exit /b 1
 
 python -m pip install -r requirements.txt || exit /b 1


### PR DESCRIPTION
Allow using the same virtual python environment for building as for debugging. This way each developer won't have to fixup the environment on their computer