### PR TITLE
WinrtServer: Extend sample with "ref" & "ref const" samples

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -65,3 +65,18 @@ TEST(WinrtServerTests, RequireThat_Buffer_ReturnsCorrectValues)
     EXPECT_EQ(buffer.size(), 8u);
     EXPECT_EQ(buffer[0], 1);
 }
+
+TEST(WinrtServerTests, RequireThat_Buffer_CanBeSetAndFilled)
+{
+    init_apartment(winrt::apartment_type::single_threaded);
+
+    winrt::WinrtServer::Programmer programmer; // will trigger WinrtServer.dll loading
+
+    std::vector<uint8_t> content = { 8, 7, 6, 5, 4, 3, 2, 1 };
+    programmer.SetBuffer(content);
+
+    std::vector<uint8_t> copy(8, 0);
+    programmer.FillBuffer(copy);
+
+    EXPECT_EQ(content, copy);
+}

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -45,4 +45,16 @@ namespace winrt::WinrtServer::implementation
         // return a copy
         return com_array<uint8_t>{ m_buffer.begin(), m_buffer.end() };
     }
+
+    void Programmer::SetBuffer(const array_view<uint8_t> buffer) {
+        m_buffer.resize(buffer.size());
+
+        for (unsigned int i = 0; i < buffer.size(); ++i)
+            m_buffer[i] = buffer[i];
+    }
+
+    void Programmer::FillBuffer(array_view<uint8_t> buffer) {
+        for (unsigned int i = 0; (i < buffer.size()) && (i < m_buffer.size()); ++i)
+            buffer[i] = m_buffer[i];
+    }
 }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -15,6 +15,10 @@ namespace winrt::WinrtServer::implementation
         Favorites GetFavorites();
         com_array<uint8_t> Buffer();
 
+        void SetBuffer(const array_view<uint8_t> buffer);
+
+        void FillBuffer(array_view<uint8_t> buffer);
+
     private:
         int m_motivation = 0;
         std::vector<uint8_t> m_buffer;

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -23,6 +23,12 @@ namespace WinrtServer
         Pos3 Add(Pos3 a, Pos3 b);
 
         UInt8[] Buffer{ get; };
+
+        // set read-only buffer (no copying of argument)
+        void SetBuffer(ref const UInt8[] buffer);
+
+        // fill caller-provided buffer with values (no copying of argument)
+        void FillBuffer(ref UInt8[] buffer);
     }
 
     runtimeclass Programmer : [default] IProgrammer


### PR DESCRIPTION
Done to share example code for how to use these marshalling attributes when authoring WinRT interfaces. An example of "out" usage is still missing though, and should be added later.