### PR TITLE
WinrtServer: Add "out" argument sample for callee-provided result

### DIFF
--- a/TutorialsAndTests/Tests/WinrtServerTests.cpp
+++ b/TutorialsAndTests/Tests/WinrtServerTests.cpp
@@ -77,6 +77,9 @@ TEST(WinrtServerTests, RequireThat_Buffer_CanBeSetAndFilled)
 
     std::vector<uint8_t> copy(8, 0);
     programmer.FillBuffer(copy);
-
     EXPECT_EQ(content, copy);
+
+    winrt::com_array<uint8_t> copy2;
+    programmer.GetBuffer(copy2);
+    EXPECT_EQ(winrt::array_view<uint8_t>(content), winrt::array_view<uint8_t>(copy2));
 }

--- a/WinrtServer/Programmer.cpp
+++ b/WinrtServer/Programmer.cpp
@@ -57,4 +57,9 @@ namespace winrt::WinrtServer::implementation
         for (unsigned int i = 0; (i < buffer.size()) && (i < m_buffer.size()); ++i)
             buffer[i] = m_buffer[i];
     }
+
+    void Programmer::GetBuffer(com_array<uint8_t>& buffer) {
+        // return a copy
+        buffer = com_array<uint8_t>{ m_buffer.begin(), m_buffer.end() };
+    }
 }

--- a/WinrtServer/Programmer.h
+++ b/WinrtServer/Programmer.h
@@ -19,6 +19,8 @@ namespace winrt::WinrtServer::implementation
 
         void FillBuffer(array_view<uint8_t> buffer);
 
+        void GetBuffer(com_array<uint8_t>& buffer);
+
     private:
         int m_motivation = 0;
         std::vector<uint8_t> m_buffer;

--- a/WinrtServer/Programmer.idl
+++ b/WinrtServer/Programmer.idl
@@ -29,6 +29,9 @@ namespace WinrtServer
 
         // fill caller-provided buffer with values (no copying of argument)
         void FillBuffer(ref UInt8[] buffer);
+
+        // get callee-allocated buffer (similar to Buffer getter)
+        void GetBuffer(out UInt8[] buffer);
     }
 
     runtimeclass Programmer : [default] IProgrammer


### PR DESCRIPTION
Done to demonstrate usage of "out" arguments in MIDL3.