### PR TITLE
Add examples on how to aggregate the free threaded marshaler

### DIFF
--- a/AtlServer/AtlHen.cpp
+++ b/AtlServer/AtlHen.cpp
@@ -15,6 +15,22 @@ HRESULT AtlHen::CluckAsync(IAsyncCluckObserver* cluckObserver)
     return cluckObserver->OnCluck();
 }
 
+HRESULT FreeThreadedHen::FinalConstruct()
+{
+    return CoCreateFreeThreadedMarshaler(GetControllingUnknown(), &m_marshaler);
+}
+
+HRESULT FreeThreadedHen::Cluck()
+{
+    assert(m_myThreadId == GetCurrentThreadId());
+    return S_OK;
+}
+
+HRESULT FreeThreadedHen::CluckAsync(IAsyncCluckObserver* cluckObserver)
+{
+    return cluckObserver->OnCluck();
+}
+
 HRESULT AtlCluckObserver::OnCluck()
 {
     assert(m_myThreadId == GetCurrentThreadId());

--- a/AtlServer/AtlHen.h
+++ b/AtlServer/AtlHen.h
@@ -26,6 +26,36 @@ private:
 OBJECT_ENTRY_AUTO(CLSID_AtlHen, AtlHen)
 
 
+
+class ATL_NO_VTABLE FreeThreadedHen :
+    public CComObjectRootEx<CComMultiThreadModel>,
+    public CComCoClass<FreeThreadedHen, &CLSID_FreeThreadedHen>,
+    public IHen
+{
+public:
+    DECLARE_REGISTRY_RESOURCEID(IDR_HEN)
+    DECLARE_PROTECT_FINAL_CONSTRUCT()
+    DECLARE_GET_CONTROLLING_UNKNOWN()
+
+    BEGIN_COM_MAP(FreeThreadedHen)
+        COM_INTERFACE_ENTRY(IHen)
+        COM_INTERFACE_ENTRY_AGGREGATE(IID_IMarshal, m_marshaler)
+    END_COM_MAP()
+
+    HRESULT FinalConstruct();
+
+    HRESULT Cluck() override;
+    HRESULT CluckAsync(IAsyncCluckObserver* cluckObserver) override;
+
+private:
+    CComPtr<IUnknown> m_marshaler;
+    unsigned long m_myThreadId = GetCurrentThreadId();
+};
+
+OBJECT_ENTRY_AUTO(CLSID_FreeThreadedHen, FreeThreadedHen)
+
+
+
 class ATL_NO_VTABLE AtlCluckObserver : public CComObjectRootEx<CComSingleThreadModel>,
     public CComCoClass<AtlCluckObserver, &CLSID_AtlCluckObserver>,
     public IAsyncCluckObserver

--- a/AtlServer/AtlHen.rgs
+++ b/AtlServer/AtlHen.rgs
@@ -25,4 +25,30 @@ HKCR
 			val AppID = s '%APPID%'
 		}
 	}
+
+	AtlServer.FreeThreadedHen.1 = s 'Free threaded Hen implementation object'
+    {
+        CLSID = s '{9c82a243-db92-4443-8513-fe1f0e46765d}'
+    }
+    AtlServer.FreeThreadedHen = s 'Free threaded Hen implementation object'
+    {
+        CLSID = s '{9c82a243-db92-4443-8513-fe1f0e46765d}'
+        CurVer = s 'AtlServer.FreeThreadedHen.1'
+    }
+
+	NoRemove CLSID
+	{
+		ForceRemove {9c82a243-db92-4443-8513-fe1f0e46765d} = s 'FreeThreadedHen class'
+		{
+			ProgID = s 'AtlServer.FreeThreadedHen.1'
+            VersionIndependentProgID = s 'AtlServer.FreeThreadedHen'
+			InprocServer32 = s '%MODULE%'
+			{
+				val ThreadingModel = s 'Both'
+			}
+		    TypeLib = s '{6ed1b1aa-807b-4a28-87b6-fcdc18ab8dc3}'
+			Version = s '1.0'
+			val AppID = s '%APPID%'
+		}
+	}
 }

--- a/AtlServer/AtlServer.idl
+++ b/AtlServer/AtlServer.idl
@@ -16,6 +16,15 @@ library AtlServer
 	};
 
 	[
+		uuid(9c82a243-db92-4443-8513-fe1f0e46765d),
+	]
+	coclass FreeThreadedHen
+	{
+		[default] interface IHen;
+	};
+
+
+	[
 		uuid(5717f50c-8aaa-433b-9077-85edc0a5efc3),
 	]
 	coclass AtlCluckObserver

--- a/AtlServer/AtlServer.vcxproj
+++ b/AtlServer/AtlServer.vcxproj
@@ -92,12 +92,14 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)\Include\;$(OutDir)\Include\Interfaces</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>AtlServer.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>../Interfaces</AdditionalIncludeDirectories>
@@ -120,6 +122,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)\Include\;$(OutDir)\Include\Interfaces</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -128,6 +131,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>AtlServer.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>../Interfaces</AdditionalIncludeDirectories>

--- a/TutorialsAndTests/Tests/AtlHenTests.cpp
+++ b/TutorialsAndTests/Tests/AtlHenTests.cpp
@@ -153,7 +153,7 @@ TEST(AtlHenTests, ObserveThat_CluckAsync_Fails_WhenCalledFromWorkerThread)
 // Test that demonstrates use of the free threaded marshaler which allows calling an object from any thread.
 TEST(FreeThreadedHenTests, RequireThat_Cluck_IsCalledOnAsyncCluckObserver_WhenCalledFromWorkerThread)
 {
-    auto observer = make_self<IAsyncCluckObserverMock>();
+    auto observer = winrt::make_self<FreeThreadedCluckObserver>();
     EXPECT_CALL(*observer, OnCluck()).WillOnce(Invoke([] {
         return S_OK;
     }));
@@ -166,7 +166,7 @@ TEST(FreeThreadedHenTests, RequireThat_Cluck_IsCalledOnAsyncCluckObserver_WhenCa
 
     auto result = std::async(std::launch::async, [&] {
         ComRuntime comRuntime{Apartment::MultiThreaded};
-        return hen->CluckAsync(observer);
+        return hen->CluckAsync(observer.get());
     });
 
     EXPECT_EQ(result.get(), S_OK);

--- a/TutorialsAndTests/Tests/Mocks/IHenMock.h
+++ b/TutorialsAndTests/Tests/Mocks/IHenMock.h
@@ -3,6 +3,7 @@
 #include <atlcom.h>
 #include <gmock/gmock.h>
 #include <Interfaces/IHen.h>
+#include <winrt/base.h>
 
 /** Mock that shows how to create local COM objects using ATL */
 struct IAsyncCluckObserverMock :
@@ -14,5 +15,15 @@ struct IAsyncCluckObserverMock :
         COM_INTERFACE_ENTRY(IAsyncCluckObserver)
     END_COM_MAP()
 
+    MOCK_METHOD(HRESULT, OnCluck, (), (override));
+};
+
+/** Mock that shows how to implement local free-threaded COM objects with winrt */
+struct FreeThreadedCluckObserver : winrt::implements<
+                                                     FreeThreadedCluckObserver, // Implementation
+                                                     IAsyncCluckObserver,       // Interface
+                                                     IAgileObject               // Support calls from any thread
+                                                    >
+{
     MOCK_METHOD(HRESULT, OnCluck, (), (override));
 };


### PR DESCRIPTION
This merge request shows how to aggregate the free threaded marshaler. This allows calling functions of a COM interface from any thread without marshaling the interface pointer.

We provide two examples here, one with ATL, and one with winrt. This highlights the power of winrt when it comes to agility.