### PR TITLE
Upgrade .Net projects to .Net 6.0 (LTS)

### DIFF
--- a/ComUtilityManaged/ComUtilityManaged.csproj
+++ b/ComUtilityManaged/ComUtilityManaged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/InteropTests/InteropTests.csproj
+++ b/InteropTests/InteropTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Platforms>x64</Platforms>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/ManagedServer/ManagedServer.csproj
+++ b/ManagedServer/ManagedServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <EnableComHosting>true</EnableComHosting>
   </PropertyGroup>


### PR DESCRIPTION
.Net 5.0 have been out of support since May 10, 2022 according to https://dotnet.microsoft.com/en-us/download/dotnet

Also added a `-windows` suffix to the `ManagedServer` project to avoid introducing the following warning: `ManagedServer\PetShop.cs(18,34,18,105): warning CA1416: This call site is reachable on all platforms. 'Type.GetTypeFromCLSID(Guid)' is only supported on: 'windows'.`